### PR TITLE
[CHAT] OkHttp로 웹소켓 통신, 재연결 구현

### DIFF
--- a/app/src/main/java/com/otclub/humate/chat/ChatWebSocketClient.kt
+++ b/app/src/main/java/com/otclub/humate/chat/ChatWebSocketClient.kt
@@ -5,10 +5,17 @@ import org.java_websocket.client.WebSocketClient
 import org.java_websocket.handshake.ServerHandshake
 import java.lang.Exception
 import java.net.URI
+import java.util.*
 
 class ChatWebSocketClient(serverUri: URI, private val headers: Map<String, String>) : WebSocketClient(serverUri, headers) {
+    private var reconnectTimer : Timer? = null
+    private val reconnectDelay : Long = 5000
+    private var isConnected = false
+
     override fun onOpen(handshakedata: ServerHandshake?) {
         Log.d("WebSocketClient","Connected to server")
+        isConnected = true
+        reconnectTimer?.cancel()
     }
 
     override fun onMessage(message: String?) {
@@ -17,9 +24,32 @@ class ChatWebSocketClient(serverUri: URI, private val headers: Map<String, Strin
 
     override fun onClose(code: Int, reason: String?, remote: Boolean) {
         Log.d("WebSocketClient","DisConnected from server")
+        isConnected = false
     }
 
     override fun onError(ex: Exception?) {
         Log.d("WebSocketClient","${ex?.message}")
     }
+
+    private fun scheduleReconnect(){
+        if(isConnected) return
+
+        reconnectTimer?.cancel()
+        reconnectTimer = Timer().apply {
+            schedule(object : TimerTask(){
+                override fun run() {
+                    reconnect()
+                }
+            }, reconnectDelay)
+        }
+    }
+
+//    private fun reconnect(){
+//        try{
+//            if(!this.isOpen){
+//                Log.d("WebSocketClient","재연결 시도합니다!")
+//                this.reconnect()
+//            }
+//        }
+//    }
 }

--- a/app/src/main/java/com/otclub/humate/chat/ChatWebSocketListener.kt
+++ b/app/src/main/java/com/otclub/humate/chat/ChatWebSocketListener.kt
@@ -1,0 +1,41 @@
+package com.otclub.humate.chat
+
+import android.util.Log
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+
+class ChatWebSocketListener : WebSocketListener() {
+
+    override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+        super.onClosed(webSocket, code, reason)
+        Log.d("WebSocket", "WebSocket 종료됨: 코드=$code, 이유=$reason")
+    }
+
+    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+        super.onClosing(webSocket, code, reason)
+        Log.d("WebSocket", "WebSocket 종료 중: 코드=$code, 이유=$reason")
+        webSocket.close(code, reason)
+    }
+
+    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+        super.onFailure(webSocket, t, response)
+        Log.e("WebSocket", "WebSocket 실패: ${t.message}")
+    }
+
+    override fun onMessage(webSocket: WebSocket, text: String) {
+        super.onMessage(webSocket, text)
+        Log.d("WebSocket", "onMessage 수신된 메시지: $text")
+    }
+
+    override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+        super.onMessage(webSocket, bytes)
+        Log.d("WebSocket", "onMessage 수신된 메시지: $bytes")
+    }
+
+    override fun onOpen(webSocket: WebSocket, response: Response) {
+        super.onOpen(webSocket, response)
+        Log.d("WebSocket", "WebSocket 연결이 성공적으로 열림. Response: $response")
+    }
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,8 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="dark_gray">#777777</color>
-    <color name="light_gray">#CCCCCC</color>
     <color name="super_light_gray">#EDEDED</color>
     <color name="nav_item_text_color_unselected">#858585</color>
     <color name="nav_item_text_color_selected">#7060FE</color>


### PR DESCRIPTION
# 💡 PR 요약
4시간동안 하던거 안돼서 Java-webSocket 라이브러리로 했는데,, OkHttp가 다시 되네요. 보편적으로 사용하는거라고 해서 다시 OkHttp로 구현했습니다 :) 

## ⭐️ 관련 이슈
- close : #20 

## 📍 작업한 내용
- 웹소켓 10초마다 재연결 메서드 구현

## 🔎 결과 및 이슈 공유
현재는 웹소켓을 10초에 한번씩 서버에 재연결하도록 구현했는데, ping-pong으로 클라이언트-서버 간의 연결 상태를 확인해서 소켓 만료시간을 연장해주는 방식도 있다고 해서 추후에 시간되면 ping-pong으로 개발할 예정입니다. (우선순위 후순위)

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/65e33fd6-be38-4914-954b-5207da0d3df0">

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
