### PR TITLE
[CHAT] 채팅 과거 내역 조회 비동기 처리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,4 +78,8 @@ dependencies {
 
     // circle image view
     implementation 'de.hdodenhof:circleimageview:2.2.0'
+
+    // coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 }

--- a/app/src/main/java/com/otclub/humate/chat/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/otclub/humate/chat/adapter/ChatAdapter.kt
@@ -56,13 +56,19 @@ class ChatAdapter(private val messages: MutableList<ChatMessageResponseDTO>, pri
             notifyItemInserted(messages.size - 1)
         }
 
+        fun updateMessages(newMessages: List<ChatMessageResponseDTO>) {
+            messages.clear()
+            messages.addAll(newMessages)
+            notifyDataSetChanged()
+        }
+
         inner class ReceivedMessageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             private val textView: TextView = itemView.findViewById(R.id.message_text)
             private val dateView: TextView = itemView.findViewById(R.id.message_time)
 
             fun bind(message: ChatMessageResponseDTO) {
                 textView.text = "${message.senderId}: ${message.content}"
-                dateView.text = formatDate(message.createdAt)
+                dateView.text = "${message.createdAt}"//formatDate(message.createdAt)
             }
         }
 
@@ -72,7 +78,7 @@ class ChatAdapter(private val messages: MutableList<ChatMessageResponseDTO>, pri
 
             fun bind(message: ChatMessageResponseDTO) {
                 textView.text = "${message.senderId}: ${message.content}"
-                dateView.text = formatDate(message.createdAt)
+                dateView.text = "${message.createdAt}" //dateView.text = formatDate(message.createdAt)
             }
         }
 

--- a/app/src/main/java/com/otclub/humate/chat/api/ChatService.kt
+++ b/app/src/main/java/com/otclub/humate/chat/api/ChatService.kt
@@ -1,0 +1,12 @@
+package com.otclub.humate.chat.api
+
+import com.otclub.humate.chat.data.ChatMessageResponseDTO
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ChatService {
+
+    @GET("/chat/{chatRoomId}")
+    fun getChatHistoryList(@Path("chatRoomId") chatRoomId: String): Call<List<ChatMessageResponseDTO>>
+}

--- a/app/src/main/java/com/otclub/humate/chat/data/ChatMessageResponseDTO.kt
+++ b/app/src/main/java/com/otclub/humate/chat/data/ChatMessageResponseDTO.kt
@@ -7,5 +7,5 @@ data class ChatMessageResponseDTO(
     val senderId : String,
     val content : String,
     val messageType : MessageType,
-    val createdAt : Date
+    val createdAt : String
 )

--- a/app/src/main/java/com/otclub/humate/chat/fragment/ChatRoomFragment.kt
+++ b/app/src/main/java/com/otclub/humate/chat/fragment/ChatRoomFragment.kt
@@ -55,6 +55,7 @@ class ChatRoomFragment  : Fragment()  {
                 val adapter = ChatRoomAdapter(it) { chatRoom ->
                     val bundle = Bundle().apply {
                         putInt("participateId", chatRoom.participateId)
+                        putString("chatRoomId", chatRoom.chatRoomId)
                     }
                     // Navigation Bar 숨기기
                     (activity as? MainActivity)?.hideBottomNavigationBar()

--- a/app/src/main/java/com/otclub/humate/chat/viewModel/ChatViewModel.kt
+++ b/app/src/main/java/com/otclub/humate/chat/viewModel/ChatViewModel.kt
@@ -1,0 +1,41 @@
+package com.otclub.humate.chat.viewModel
+
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.otclub.humate.chat.api.ChatService
+import com.otclub.humate.chat.data.ChatMessageResponseDTO
+import com.otclub.humate.retrofit.RetrofitConnection
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class ChatViewModel : ViewModel() {
+    private val chatService : ChatService = RetrofitConnection.getInstance().create(ChatService::class.java)
+    val chatHistoryList = MutableLiveData<List<ChatMessageResponseDTO>>()
+
+    // 채팅 메시지 리스트를 업데이트
+    fun setChatHistory(newMessages: List<ChatMessageResponseDTO>) {
+        chatHistoryList.value = newMessages
+    }
+
+    fun fetchChatHistoryList(chatRoomId: String?)  {
+
+        chatService.getChatHistoryList(chatRoomId!!).enqueue(object :
+            Callback<List<ChatMessageResponseDTO>> {
+            override fun onResponse(
+                call: Call<List<ChatMessageResponseDTO>>,
+                response: Response<List<ChatMessageResponseDTO>>
+            ) {
+                if (response.isSuccessful && response.body() != null) {
+                    Log.i("chatHistoryList : ", response.body().toString())
+                    chatHistoryList.value = response.body();
+                }
+            }
+
+            override fun onFailure(call: Call<List<ChatMessageResponseDTO>>, t: Throwable) {
+                Log.e("채팅 목록 페이지 응답 실패 ", t.toString())
+            }
+        })
+    }
+}


### PR DESCRIPTION
# 💡 PR 요약
채팅방을 입장 시, 웹소켓 연결과 채팅 과거 내역 조회 API 호출을 비동기 처리로 구현했습니다. 

## ⭐️ 관련 이슈
- close : #62 

## 📍 작업한 내용
- 채팅 과거 내역 조회 recyclerView
- 채팅 과거 내역 조회와 웹소켓 연결 비동기 처리

## 🔎 결과 및 이슈 공유
아직 화면 전환, 상단 내용 연결 해야합니다 ^&^

<img width="557" alt="스크린샷 2024-08-04 오후 11 54 11" src="https://github.com/user-attachments/assets/242bb054-e415-4742-ab0b-4f04fed7060d">

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
